### PR TITLE
Protect rescheduling operation with a transaction

### DIFF
--- a/neutron/extensions/l3agentscheduler.py
+++ b/neutron/extensions/l3agentscheduler.py
@@ -179,7 +179,7 @@ class L3AgentSchedulerPluginBase(object):
         pass
 
     @abstractmethod
-    def remove_router_from_l3_agent(self, context, id, router_id):
+    def remove_router_from_l3_agent(self, context, id, router_id, notify):
         pass
 
     @abstractmethod

--- a/neutron/tests/unit/bigswitch/test_servermanager.py
+++ b/neutron/tests/unit/bigswitch/test_servermanager.py
@@ -58,7 +58,7 @@ class ServerManagerTests(test_rp.BigSwitchProxyPluginV2TestCase):
                 *('example.org', 443)
             )
             sslgetmock.assert_has_calls([mock.call(
-                  ('example.org', 443), ssl_version=ssl.PROTOCOL_TLSv1)])
+                ('example.org', 443), ssl_version=ssl.PROTOCOL_TLSv1)])
 
     def test_consistency_watchdog_stops_with_0_polling_interval(self):
         pl = NeutronManager.get_plugin()


### PR DESCRIPTION
Place the unschedule and schedule functions of the router
rescheduling operation in a transaction so the failure of
a scheduling doesn't leave the router unscheduled.

Change-Id: I35c5cd431db580f57b2dca4b81dea659d2059cd2
Closes-Bug: #BVS-2623

Reviewer: @kjiang 
