### PR TITLE
Juno backport l3 rpc improvements

### DIFF
--- a/neutron/db/l3_db.py
+++ b/neutron/db/l3_db.py
@@ -1051,7 +1051,7 @@ class L3_NAT_dbonly_mixin(l3.RouterPluginBase):
             context, router_ids=router_ids, active=active)
         ports_to_populate = [router['gw_port'] for router in routers
                              if router.get('gw_port')] + interfaces
-        self._populate_subnets_for_ports(context, ports_to_populate)
+        self._populate_subnet_for_ports(context, ports_to_populate)
         routers_dict = dict((router['id'], router) for router in routers)
         self._process_floating_ips(context, routers_dict, floating_ips)
         self._process_interfaces(routers_dict, interfaces)

--- a/neutron/db/l3_dvr_db.py
+++ b/neutron/db/l3_dvr_db.py
@@ -368,7 +368,7 @@ class L3_NAT_with_dvr_db_mixin(l3_db.L3_NAT_db_mixin,
             if router.get(l3_const.FLOATINGIP_AGENT_INTF_KEY):
                 ports_to_populate += router[l3_const.FLOATINGIP_AGENT_INTF_KEY]
         ports_to_populate += interfaces
-        self._populate_subnets_for_ports(context, ports_to_populate)
+        self._populate_subnet_for_ports(context, ports_to_populate)
         self._process_interfaces(routers_dict, interfaces)
         return routers_dict.values()
 

--- a/neutron/db/l3_dvr_db.py
+++ b/neutron/db/l3_dvr_db.py
@@ -455,12 +455,12 @@ class L3_NAT_with_dvr_db_mixin(l3_db.L3_NAT_db_mixin,
                               'admin_state_up': True,
                               'name': ''}})
                 if agent_port:
-                    self._populate_subnets_for_ports(context, [agent_port])
+                    self._populate_subnet_for_ports(context, [agent_port])
                     return agent_port
                 msg = _("Unable to create the Agent Gateway Port")
                 raise n_exc.BadRequest(resource='router', msg=msg)
             else:
-                self._populate_subnets_for_ports(context, [f_port])
+                self._populate_subnet_for_ports(context, [f_port])
                 return f_port
 
     def get_snat_interface_ports_for_router(self, context, router_id):
@@ -501,7 +501,7 @@ class L3_NAT_with_dvr_db_mixin(l3_db.L3_NAT_db_mixin,
             context.session.add(router_port)
 
         if do_pop:
-            return self._populate_subnets_for_ports(context, [snat_port])
+            return self._populate_subnet_for_ports(context, [snat_port])
         return snat_port
 
     def create_snat_intf_ports_if_not_exists(self, context, router):
@@ -514,7 +514,7 @@ class L3_NAT_with_dvr_db_mixin(l3_db.L3_NAT_db_mixin,
         port_list = self.get_snat_interface_ports_for_router(
             context, router.id)
         if port_list:
-            self._populate_subnets_for_ports(context, port_list)
+            self._populate_subnet_for_ports(context, port_list)
             return port_list
         port_list = []
 
@@ -536,7 +536,7 @@ class L3_NAT_with_dvr_db_mixin(l3_db.L3_NAT_db_mixin,
                     intf['fixed_ips'][0]['subnet_id'], do_pop=False)
                 port_list.append(snat_port)
         if port_list:
-            self._populate_subnets_for_ports(context, port_list)
+            self._populate_subnet_for_ports(context, port_list)
         return port_list
 
     def dvr_vmarp_table_update(self, context, port_id, action):

--- a/neutron/db/l3_hamode_db.py
+++ b/neutron/db/l3_hamode_db.py
@@ -449,7 +449,7 @@ class L3_HA_NAT_db_mixin(l3_dvr_db.L3_NAT_with_dvr_db_mixin):
         for router in routers_dict.values():
             interface = router.get(constants.HA_INTERFACE_KEY)
             if interface:
-                self._populate_subnets_for_ports(context, [interface])
+                self._populate_subnet_for_ports(context, [interface])
 
         return routers_dict.values()
 

--- a/neutron/tests/unit/db/test_l3_ha_db.py
+++ b/neutron/tests/unit/db/test_l3_ha_db.py
@@ -119,8 +119,7 @@ class L3HAGetSyncDataTestCase(L3HATestFramework):
 
         self.assertEqual(constants.DEVICE_OWNER_ROUTER_HA_INTF,
                          interface['device_owner'])
-        self.assertEqual(cfg.CONF.l3_ha_net_cidr,
-                         interface['subnets'][0]['cidr'])
+        self.assertEqual(cfg.CONF.l3_ha_net_cidr, interface['subnet']['cidr'])
 
     def test_update_state(self):
         router = self._create_router()

--- a/neutron/tests/unit/test_l3_plugin.py
+++ b/neutron/tests/unit/test_l3_plugin.py
@@ -1804,7 +1804,7 @@ class L3AgentDbTestCaseBase(L3NatTestCaseMixin):
                 self.assertEqual(1, len(routers))
                 interfaces = routers[0][l3_constants.INTERFACE_KEY]
                 self.assertEqual(1, len(interfaces))
-                subnet_id = interfaces[0]['subnets'][0]['id']
+                subnet_id = interfaces[0]['subnet']['id']
                 wanted_subnetid = p['port']['fixed_ips'][0]['subnet_id']
                 self.assertEqual(wanted_subnetid, subnet_id)
                 # clean-up
@@ -1850,8 +1850,7 @@ class L3AgentDbTestCaseBase(L3NatTestCaseMixin):
                     context.get_admin_context(), [r['router']['id']])
                 self.assertEqual(1, len(routers))
                 gw_port = routers[0]['gw_port']
-                self.assertEqual(s['subnet']['id'],
-                                 gw_port['subnets'][0]['id'])
+                self.assertEqual(s['subnet']['id'], gw_port['subnet']['id'])
                 self._remove_external_gateway_from_router(
                     r['router']['id'],
                     s['subnet']['network_id'])


### PR DESCRIPTION
 _populate_subnet_for_ports became _populate_subnets_for_ports
in Kilo. The back-ported performance improvements were calling
the new version. The previous changes tried to backport the
newer function, but that was too invasive so that was reverted
and the improvement fixes were tweaked to call the older function.
